### PR TITLE
Fixed vendor path

### DIFF
--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -1,7 +1,7 @@
 includes:
-    - /composer/vendor/symplify/easy-coding-standard/config/php_codesniffer/psr2.neon
-    - /composer/vendor/symplify/easy-coding-standard/config/php_cs_fixer/psr2.neon
-    - /composer/vendor/symplify/easy-coding-standard/config/clean-code.neon
+    - ../../../vendor/symplify/easy-coding-standard/config/php_codesniffer/psr2.neon
+    - ../../../vendor/symplify/easy-coding-standard/config/php_cs_fixer/psr2.neon
+    - ../../../vendor/symplify/easy-coding-standard/config/clean-code.neon
 
 checkers:
     PhpCsFixer\Fixer\Operator\ConcatSpaceFixer:


### PR DESCRIPTION
 to make coding standards runnable via bin/easy-coding-standard (used for sylius plugins)