### PR TITLE
Added destination_dir 

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -70,3 +70,4 @@ jobs:
                 aws_secret_access_key: ${{ secrets.S3_BUILD_SECRET_KEY }}
                 aws_bucket: ${{ secrets.S3_BUILD_BUCKET }}
                 source_dir: 'build'
+                destination_dir: 'phar'


### PR DESCRIPTION
because we want to upload the build directory content to the phar directory in the s3 bucket