### PR TITLE
BUGFIX: Restore the support of PHARs by the Easy Coding Standard

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -43,7 +43,6 @@ jobs:
 
             - name: script
               run: |
-                composer validate --strict
                 vendor/bin/ecs check tests
 
             - name: after success

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -38,8 +38,8 @@ jobs:
 
             - name: Composer install
               run: |
-                composer global require humbug/box
-                composer update --prefer-dist
+                if ( [ "${{ matrix.php-version }}" == "8.1" ] ); then composer global require humbug/box:^3.16 --ignore-platform-reqs; else composer global require humbug/box; fi
+                composer update
 
             - name: script
               run: |

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -16,7 +16,7 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-version }}
-                  tools: composer:v1
+                  tools: composer:v2
 
             - uses: actions/checkout@v2
               with:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Installation & usage
 Phar usage
 ----------
 
-To create the phar, you need to install ```kherge/box``` globally:
+To create the phar, you need to install ```humbug/box``` globally:
 (The global composer bin path needs to be available in $PATH)
 
-    composer global require kherge/box
+    composer global require humbug/box
 
 Install the dependencies
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.1||^8.0",
+        "php": "^7.4||^8.0",
         "symplify/easy-coding-standard": "^11.0",
         "symplify/package-builder": "^9.0",
         "slevomat/coding-standard": "^8.0"

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         }
     },
     "extra": {
+        "composer-exit-on-patch-failure": true,
         "patches": {
             "symplify/easy-coding-standard": {
                 "Adjust autoloader for PHAR support": "patches/adjust-autoloader-for-phar-support.patch"

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,26 @@
     "require": {
         "php": "^7.4||^8.0",
         "symplify/easy-coding-standard": "^11.0",
-        "symplify/package-builder": "^9.0",
-        "slevomat/coding-standard": "^8.0"
+        "slevomat/coding-standard": "^8.0",
+        "cweagans/composer-patches": "^1.7"
     },
-    "autoload": {
+    "patches": {
+        "symplify/easy-coding-standard": {
+            "Adjust autoloader for PHAR support": "patches/adjust-autoloader-for-phar-support.patch"
+        }
+    },
+    "config": {
+        "preferred-install": "source",
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "cweagans/composer-patches": true
+        }
+    },
+    "extra": {
+        "patches": {
+            "symplify/easy-coding-standard": {
+                "Adjust autoloader for PHAR support": "patches/adjust-autoloader-for-phar-support.patch"
+            }
+        }
     }
 }

--- a/patches/adjust-autoloader-for-phar-support.patch
+++ b/patches/adjust-autoloader-for-phar-support.patch
@@ -1,0 +1,53 @@
+--- a/bin/ecs.php
++++ b/bin/ecs.php
+@@ -20,7 +20,8 @@
+ }
+ $autoloadIncluder->includeCwdVendorAutoloadIfExists();
+ $autoloadIncluder->loadIfNotLoadedYet(__DIR__ . '/../vendor/scoper-autoload.php');
+-$autoloadIncluder->autoloadProjectAutoloaderFile('/../../autoload.php');
++// Disable the following function since the autoloader is already loaded via the PHAR stub
++// $autoloadIncluder->autoloadProjectAutoloaderFile('/../../autoload.php');
+ $autoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists();
+ $autoloadIncluder->includePhpCodeSnifferAutoloadIfNotInPharAndInitliazeTokens();
+ /**
+@@ -106,13 +107,36 @@
+         if (\in_array($file, $this->alreadyLoadedAutoloadFiles, \true)) {
+             return;
+         }
+-        $realPath = \realpath($file);
+-        if (!\is_string($realPath)) {
+-            return;
+-        }
++        // Use a custom function to normalize the path, since realpath cannot be used in the PHAR file context.
++        $realPath = $this->normalizePath($file);
+         $this->alreadyLoadedAutoloadFiles[] = $realPath;
+         require_once $file;
+     }
++
++    /**
++     * @source https://stackoverflow.com/a/20545583
++     */
++    private function normalizePath($path, $separator = '\\/')
++    {
++        // Remove any kind of funky unicode whitespace
++        $normalized = preg_replace('#\p{C}+|^\./#u', '', $path);
++
++        // Path remove self referring paths ("/./").
++        $normalized = preg_replace('#/\.(?=/)|^\./|\./$#', '', $normalized);
++
++        // Regex for resolving relative paths
++        $regex = '#\/*[^/\.]+/\.\.#Uu';
++
++        while (preg_match($regex, $normalized)) {
++            $normalized = preg_replace($regex, '', $normalized);
++        }
++
++        if (preg_match('#/\.{2}|\.{2}/#', $normalized)) {
++            throw new LogicException('Path is outside of the defined root, path: [' . $path . '], resolved: [' . $normalized . ']');
++        }
++
++        return trim($normalized, $separator);
++    }
+ }
+ try {
+     $input = new ArgvInput();


### PR DESCRIPTION
Since the newest versions of symplify/easy-coding-standard now use a prefix for dependencies which requires a custom solution for the autoloader, it is necessary to patch this autoloader in order to be able to continue using the Easy Coding Standard within a PHAR.