### PR TITLE
Add a step to run the generated phar against the tests directory

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -55,6 +55,7 @@ jobs:
             - name: before deploy
               run: | 
                 box compile
+                ./build/ecs-standalone.phar check tests
                 mv ./build/ecs-standalone.phar ./build/coding-standard-standalone.ecs.php${{ matrix.php-version }}.phar
 
             - name: deploy

--- a/ecs.php
+++ b/ecs.php
@@ -6,7 +6,7 @@ use PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return static function (ECSConfig $ecsConfig): void {
-    $ecsConfig->paths([__DIR__ . 'tests/']);
+    $ecsConfig->paths([__DIR__ . '/tests/']);
 
     $ecsConfig->parallel();
 


### PR DESCRIPTION
Because we want to ensure that the generated phar is working