### PR TITLE
BUGFIX: Ensure that there is no duplication of the autoloader in the CodingStandard repo

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -48,10 +48,7 @@ jobs:
 
             - name: after success
               run: |
-                if ( [ "${{ matrix.php-version }}" == "7.4" ] ); then cp ./ecs.php ./build/ecs7.3.php; fi
-                if ( [ "${{ matrix.php-version }}" == "7.4" ] ); then cp ./ecs.php ./build/ecs7.4.php; fi
-                if ( [ "${{ matrix.php-version }}" == "7.4" ] ); then cp ./ecs.php ./build/ecs8.0.php; fi
-                if ( [ "${{ matrix.php-version }}" == "7.4" ] ); then cp ./ecs.php ./build/ecs8.1.php; fi
+                cp ./ecs.php ./build/ecs${{ matrix.php-version }}.php
 
             - name: before deploy
               run: | 

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -43,6 +43,7 @@ jobs:
 
             - name: script
               run: |
+                composer validate --strict
                 vendor/bin/ecs check tests
 
             - name: after success

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,6 @@
         "slevomat/coding-standard": "^8.0",
         "cweagans/composer-patches": "^1.7"
     },
-    "patches": {
-        "symplify/easy-coding-standard": {
-            "Adjust autoloader for PHAR support": "patches/adjust-autoloader-for-phar-support.patch"
-        }
-    },
     "config": {
         "preferred-install": "source",
         "allow-plugins": {

--- a/patches/adjust-autoloader-for-phar-support.patch
+++ b/patches/adjust-autoloader-for-phar-support.patch
@@ -1,16 +1,28 @@
 --- a/bin/ecs.php
 +++ b/bin/ecs.php
-@@ -20,7 +20,8 @@
- }
- $autoloadIncluder->includeCwdVendorAutoloadIfExists();
- $autoloadIncluder->loadIfNotLoadedYet(__DIR__ . '/../vendor/scoper-autoload.php');
--$autoloadIncluder->autoloadProjectAutoloaderFile('/../../autoload.php');
-+// Disable the following function since the autoloader is already loaded via the PHAR stub
-+// $autoloadIncluder->autoloadProjectAutoloaderFile('/../../autoload.php');
- $autoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists();
- $autoloadIncluder->includePhpCodeSnifferAutoloadIfNotInPharAndInitliazeTokens();
- /**
-@@ -106,13 +107,36 @@
+@@ -69,6 +69,21 @@
+         if (!\is_file($path)) {
+             return;
+         }
++
++        // Verify that the autoloader has not already been included during the creation of the PHAR.
++        $composerAutoloadInitClassNames = array_filter(
++            get_declared_classes(),
++            fn($className) => preg_match('/^ComposerAutoloaderInit/', $className)
++        );
++
++        $autoloaderSource = file_get_contents($path);
++        foreach ($composerAutoloadInitClassNames as $autoloadInitClassName) {
++            if (strpos($autoloaderSource, $autoloadInitClassName) !== false) {
++                echo $autoloadInitClassName . 'is already loaded';
++                return;
++            }
++        }
++
+         $this->loadIfNotLoadedYet($path);
+     }
+     public function includePhpCodeSnifferAutoloadIfNotInPharAndInitliazeTokens() : void
+@@ -106,13 +121,36 @@
          if (\in_array($file, $this->alreadyLoadedAutoloadFiles, \true)) {
              return;
          }


### PR DESCRIPTION
Loading the autoloader is necessary outside of this repository. However, within this repository, the autoloader is already included and loaded as part of the PHAR generation process.